### PR TITLE
fix(macos): fresh Mac setup fails on git shim and Claude Code PATH

### DIFF
--- a/src/os/macos/files/.bash_profile
+++ b/src/os/macos/files/.bash_profile
@@ -34,6 +34,9 @@ if [[ -f /usr/local/bin/brew ]]; then
     eval "$(/usr/local/bin/brew shellenv)"
 fi
 
+# Claude Code
+export PATH="$HOME/.claude/bin:$PATH"
+
 # ------------------------------------------------------------------------------
 # NVM (Node Version Manager)
 # ------------------------------------------------------------------------------

--- a/src/os/macos/files/.zshrc
+++ b/src/os/macos/files/.zshrc
@@ -33,6 +33,9 @@ export PATH="$HOME/go/bin:$PATH"
 export BUN_INSTALL="$HOME/.bun"
 export PATH="$BUN_INSTALL/bin:$PATH"
 
+# Claude Code
+export PATH="$HOME/.claude/bin:$PATH"
+
 
 # ------------------------------------------------------------------------------
 # NVM (Node Version Manager)

--- a/src/os/macos/installers/claude-code.sh
+++ b/src/os/macos/installers/claude-code.sh
@@ -4,7 +4,7 @@ set -e
 APP_NAME="Claude Code"
 
 # 1. CHECK - Skip if already installed
-if command -v claude >/dev/null 2>&1; then
+if command -v claude >/dev/null 2>&1 || [ -x "$HOME/.claude/bin/claude" ]; then
     echo "$APP_NAME is already installed."
     exit 0
 fi
@@ -19,7 +19,12 @@ fi
 echo "Installing $APP_NAME..."
 curl -fsSL https://claude.ai/install.sh | bash
 
-# 4. VERIFY - Confirm installation succeeded
+# 4. ADD TO PATH - Installer drops binary in ~/.claude/bin which may not be on PATH yet
+if ! command -v claude >/dev/null 2>&1 && [ -x "$HOME/.claude/bin/claude" ]; then
+    export PATH="$HOME/.claude/bin:$PATH"
+fi
+
+# 5. VERIFY - Confirm installation succeeded
 if command -v claude >/dev/null 2>&1; then
     echo "$APP_NAME installed successfully."
 else

--- a/src/setup.sh
+++ b/src/setup.sh
@@ -29,7 +29,7 @@ if [ -d "$TARGET_DIR" ] && [ -d "$TARGET_DIR/.git" ]; then
 elif [ -d "$TARGET_DIR" ]; then
     echo "Files already present in $TARGET_DIR (no git repo). Skipping download."
 else
-    if command -v git >/dev/null 2>&1; then
+    if command -v git >/dev/null 2>&1 && git --version >/dev/null 2>&1; then
         echo "Cloning dotfiles..."
         git clone "$REPO_URL" "$TARGET_DIR"
     else


### PR DESCRIPTION
## Summary
- **setup.sh**: On a fresh Mac, `/usr/bin/git` is a shim that triggers the Xcode CLT install dialog instead of cloning. Added `git --version` check so the script falls through to the tarball download path when git isn't functional.
- **claude-code.sh**: The official installer drops the binary in `~/.claude/bin/` which isn't on PATH in the running session. The verify step (`command -v claude`) then fails and `set -e` kills the entire setup. Now adds `~/.claude/bin` to PATH after install and checks for the binary directly in the idempotency check.
- **.zshrc / .bash_profile**: Added `~/.claude/bin` to PATH so `claude` is available in new terminal sessions.

## Test plan
- [ ] Run `setup.sh` via curl on a fresh macOS VM with no Xcode CLT installed — should download via tarball instead of failing on git shim
- [ ] Verify Claude Code installs successfully and the setup continues past it
- [ ] Open a new terminal after setup and verify `claude` is on PATH

🤖 Generated with [Claude Code](https://claude.com/claude-code)